### PR TITLE
Removed redundant auth error match

### DIFF
--- a/app/v2/services/EnrolmentsAuthService.scala
+++ b/app/v2/services/EnrolmentsAuthService.scala
@@ -38,7 +38,7 @@ class EnrolmentsAuthService @Inject()(val connector: AuthConnector) {
     authFunction.authorised(predicate) {
       Future.successful(Right(true))
     } recoverWith {
-      case _: MissingBearerToken | _: AuthorisationException => Future.successful(Left(UnauthorisedError))
+      case _: AuthorisationException => Future.successful(Left(UnauthorisedError))
       case error =>
         Logger.warn(s"[EnrolmentsAuthService][authorised] An unexpected error occurred: $error")
         Future.successful(Left(DownstreamError))


### PR DESCRIPTION
`MissingBearerToken` extends `AuthorisationException` so the latter check is enough on it's own.